### PR TITLE
Drop the pserve option --monitor-restart in start.sh

### DIFF
--- a/fishtest/start.sh
+++ b/fishtest/start.sh
@@ -4,4 +4,4 @@ pkill -f start_fishtest
 pkill -f pserve
 
 cd /home/fishtest/fishtest/fishtest
-nohup pserve --monitor-restart production.ini >nohup.out &
+nohup pserve production.ini >nohup.out &


### PR DESCRIPTION
The pserve option --monitor-restart, already deprecated in Pyramid 1.6.x and 1.7.x,
was dropped with Pyramid 1.8.x.
Option deleted from start.sh to run fishtest server on latest Pyramid.