### PR TITLE
Use "make" instead of the custom "mingw32-make"

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -47,6 +47,7 @@ MAKE_CMD = 'make profile-build COMP=gcc ' + ARCH
 
 if IS_WINDOWS:
   EXE_SUFFIX = '.exe'
+  MAKE_CMD = 'make profile-build COMP=mingw ' + ARCH
 
 def binary_filename(sha):
   system = platform.uname()[0].lower()

--- a/worker/games.py
+++ b/worker/games.py
@@ -47,7 +47,6 @@ MAKE_CMD = 'make profile-build COMP=gcc ' + ARCH
 
 if IS_WINDOWS:
   EXE_SUFFIX = '.exe'
-  MAKE_CMD = 'mingw32-make profile-build COMP=mingw ' + ARCH
 
 def binary_filename(sha):
   system = platform.uname()[0].lower()


### PR DESCRIPTION
Use the standard "make" command instead of the custom "mingw32-make" command to build the applications with a Windows worker.
In this way fishtest will work out of the box with all the MinGW-w64 distributions (MSYS distribution provides also the "make" command that works fine)