### PR TITLE
Update AUTHORS for Multi Variant Fishtest

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,7 +12,7 @@ Michel Van den Bergh
 
 # Generated with 'git shortlog -sn | cut -c8-', which sorts by commits, merged duplicates
 
-Fabian Fitcher (ianfab)
+Fabian Ficther (ianfab)
 Kamyar Kaviani
 Werner Fenchel
 Pasquale Pigazzini (ppigazzini)

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,7 +12,7 @@ Michel Van den Bergh
 
 # Generated with 'git shortlog -sn | cut -c8-', which sorts by commits, merged duplicates
 
-Fabian Ficther (ianfab)
+Fabian Fichter (ianfab)
 Kamyar Kaviani
 Werner Fenchel
 Pasquale Pigazzini (ppigazzini)

--- a/AUTHORS
+++ b/AUTHORS
@@ -2,15 +2,32 @@
  AUTHORS (in chronological order)
 ==================================
 
-Gary Linscott
-Marco Costalba
-Lucas Braesch
-Joona Kiiski
+Gary Linscott (glinscott)
+Marco Costalba (mcostalba)
+Lucas Braesch (lucasart)
+Joona Kiiski (zamar)
 Jean-Francois Romang
 Dariusz Orzechowski
 Michel Van den Bergh
+
+# Generated with 'git shortlog -sn | cut -c8-', which sorts by commits, merged duplicates
+
+Fabian Fitcher (ianfab)
+Kamyar Kaviani
+Werner Fenchel
+Pasquale Pigazzini (ppigazzini)
+Vince Negri
+David Zar
+FieryDragonLord
+Stefano Cardanobile (Stefano80)
+fishtest
+hxim
+Jörg Oster (joergoster)
+theo77186
+
 
 Thanks to:
 Ilari Pihlajisto - cutechess, which drives all the games!
 Tord Romstad
 http://flag-sprites.com/ - For the great flag sprites
+


### PR DESCRIPTION
Added new contributors to AUTHORS file, list generated with
'git shortlog -sn | cut -c8-', which sorts by commits,
merged duplicates, original names kept in first section.