### PR TITLE
Add "Show/Hide" button for the table of running machines 

### DIFF
--- a/fishtest/fishtest/templates/tests.mak
+++ b/fishtest/fishtest/templates/tests.mak
@@ -25,6 +25,7 @@
      cores ${'%.2fM' % (nps / (cores * 1000000.0 + 1))} nps
      (${'%.2fM' % (nps / (1000000.0 + 1))} total nps)
      ${games_per_minute} games/minute
+<button id="machines-button" class="btn" data-toggle="collapse" data-target="#machines">Show</button>
  </h3>
  <table class="table table-striped table-condensed" style="max-width:960px">
   <thead>
@@ -59,6 +60,7 @@
  %endif
   </tbody>
  </table>
+</div>
 %else:
  <h3>Active - ${len(runs['active'])} tests</h3>
 %endif
@@ -90,5 +92,18 @@ $("#pending-button").click(function() {
   var active = $(this).text() == 'Hide';
   $(this).text(active ? 'Show' : 'Hide');
   $.cookie('pending_state', $(this).text());
+});
+</script>
+
+<script type="text/javascript">
+if ($.cookie('machines_state') == 'Hide') {
+  $('#machines').addClass('in');
+  $('#machines-button').text('Hide');
+}
+
+$("#machines-button").click(function() {
+  var active = $(this).text() == 'Hide';
+  $(this).text(active ? 'Show' : 'Hide');
+  $.cookie('machines_state', $(this).text());
 });
 </script>

--- a/fishtest/fishtest/templates/tests.mak
+++ b/fishtest/fishtest/templates/tests.mak
@@ -27,6 +27,7 @@
      ${games_per_minute} games/minute
 <button id="machines-button" class="btn" data-toggle="collapse" data-target="#machines">Show</button>
  </h3>
+<div class="collapse" id="machines">
  <table class="table table-striped table-condensed" style="max-width:960px">
   <thead>
    <tr>

--- a/fishtest/fishtest/templates/tests.mak
+++ b/fishtest/fishtest/templates/tests.mak
@@ -27,41 +27,41 @@
      ${games_per_minute} games/minute
 <button id="machines-button" class="btn" data-toggle="collapse" data-target="#machines">Show</button>
  </h3>
-<div class="collapse" id="machines">
- <table class="table table-striped table-condensed" style="max-width:960px">
-  <thead>
-   <tr>
-    <th>Machine</th>
-    <th>Cores</th>
-    <th>MNps</th>
-    <th>System</th>
-    <th>Version</th>
-    <th>Running on</th>
-    <th>Last updated</th>
-   </tr>
-  </thead>
-  <tbody>
- %for machine in machines:
-   <tr>
-    <td>${machine['username']}</td>
-    <td>
-    %if 'country_code' in machine:
-      <div class="flag flag-${machine['country_code'].lower()}" style="display:inline-block"></div>
-    %endif
-    ${machine['concurrency']}</td>
-    <td>${'%.2f' % (machine['nps'] / 1000000.0)}</td>
-    <td>${machine['uname']}</td>
-    <td>${machine['version']}</td>
-    <td><a href="/tests/view/${machine['run']['_id']}">${machine['run']['args']['new_tag']}</td>
-    <td>${machine['last_updated']}</td>
-   </tr>
- %endfor
- %if len(machines) == 0:
-   <td>No machines running</td>
- %endif
-  </tbody>
- </table>
-</div>
+ <div class="collapse" id="machines">
+  <table class="table table-striped table-condensed" style="max-width:960px">
+   <thead>
+    <tr>
+     <th>Machine</th>
+     <th>Cores</th>
+     <th>MNps</th>
+     <th>System</th>
+     <th>Version</th>
+     <th>Running on</th>
+     <th>Last updated</th>
+    </tr>
+   </thead>
+   <tbody>
+  %for machine in machines:
+    <tr>
+     <td>${machine['username']}</td>
+     <td>
+     %if 'country_code' in machine:
+       <div class="flag flag-${machine['country_code'].lower()}" style="display:inline-block"></div>
+     %endif
+     ${machine['concurrency']}</td>
+     <td>${'%.2f' % (machine['nps'] / 1000000.0)}</td>
+     <td>${machine['uname']}</td>
+     <td>${machine['version']}</td>
+     <td><a href="/tests/view/${machine['run']['_id']}">${machine['run']['args']['new_tag']}</td>
+     <td>${machine['last_updated']}</td>
+    </tr>
+  %endfor
+  %if len(machines) == 0:
+    <td>No machines running</td>
+  %endif
+   </tbody>
+  </table>
+ </div>
 %else:
  <h3>Active - ${len(runs['active'])} tests</h3>
 %endif


### PR DESCRIPTION
Whit a high number of CPU contributors the table of running machines is very long,
to view the tables of running tests and finished tests is required some scrolling.

Add a "Show/Hide" button for the table of running machines,
the page is loaded with the table hidden.