### PR TITLE
Lower the minimum nps required to run fishtest at 600 knps

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -160,7 +160,7 @@ def kill_process(p):
 
 def adjust_tc(tc, base_nps, concurrency):
   factor = 1600000.0 / base_nps
-  if base_nps < 700000:
+  if base_nps < 600000:
     sys.stderr.write('This machine is too slow to run fishtest effectively - sorry!\n')
     sys.exit(1)
 


### PR DESCRIPTION
Multi Variant Stockfish code is 10% slower than Official Stockfish code,
and some variants are getting slower (but stronger Elo wise) respect to some months ago.
Lower the minimum nps required to run fishtest at 600 knps
in order to keep all workers up and running.