### PR TITLE
Keep a cache of compiled SF binaries.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import datetime
 import json
 import os
+import glob
 import stat
 import requests
 import subprocess
@@ -44,16 +45,11 @@ FISHCOOKING_URL = 'https://github.com/ianfab/FishCooking'
 BOOKS_URL = 'https://github.com/ianfab/books'
 ARCH = 'ARCH=x86-64-modern' if is_64bit() else 'ARCH=x86-32'
 EXE_SUFFIX = ''
-MAKE_CMD = 'make profile-build COMP=gcc ' + ARCH
+MAKE_CMD = 'make COMP=gcc ' + ARCH
 
 if IS_WINDOWS:
   EXE_SUFFIX = '.exe'
-  MAKE_CMD = 'make profile-build COMP=mingw ' + ARCH
-
-def binary_filename(sha):
-  system = platform.uname()[0].lower()
-  architecture = '64' if is_64bit() else '32'
-  return sha + '_' + system + '_' + architecture
+  MAKE_CMD = 'make COMP=mingw ' + ARCH
 
 def github_api(repo):
   """ Convert from https://github.com/<user>/<repo>
@@ -129,7 +125,11 @@ def setup_engine(destination, worker_dir, sha, repo_url, concurrency):
       make_cmd = m.read().strip()
     subprocess.check_call(make_cmd, shell=True)
   else:
-    subprocess.check_call(MAKE_CMD + ' -j %s' % (concurrency), shell=True)
+    subprocess.check_call(MAKE_CMD + ' -j %s' % (concurrency) + ' profile-build', shell=True)
+    try: # try/pass needed for backwards compatibility with older stockfish, where 'make strip' fails under mingw.
+      subprocess.check_call(MAKE_CMD + ' -j %s' % (concurrency) + ' strip', shell=True)
+    except:
+      pass
 
   shutil.move('stockfish'+ EXE_SUFFIX, destination)
   os.chdir(worker_dir)
@@ -348,25 +348,28 @@ def run_games(worker_info, password, remote, run, task_id):
   if not os.path.exists(testing_dir):
     os.makedirs(testing_dir)
 
-  new_engine = os.path.join(testing_dir, 'stockfish' + EXE_SUFFIX)
-  base_engine = os.path.join(testing_dir, 'base' + EXE_SUFFIX)
+  # clean up old engines (keeping the 25 most recent)
+  engines = glob.glob(os.path.join(testing_dir, 'stockfish_*' + EXE_SUFFIX))
+  engines.sort(key=os.path.getmtime)
+  if len(engines) > 25:
+    for old_engine in engines[:len(engines)-25]:
+      os.remove(old_engine)
+
+  # create new one
+  sha_new = run['args']['resolved_new']
+  sha_base = run['args']['resolved_base']
+  new_engine_name = 'stockfish_' + sha_new
+  base_engine_name = 'stockfish_' + sha_base
+
+  new_engine = os.path.join(testing_dir, new_engine_name + EXE_SUFFIX)
+  base_engine = os.path.join(testing_dir, base_engine_name + EXE_SUFFIX)
   cutechess = os.path.join(testing_dir, 'cutechess-cli' + EXE_SUFFIX)
 
-  # We have already run another task from the same run ?
-  run_id_file = os.path.join(testing_dir, 'run_id.txt')
-  if os.path.exists(run_id_file):
-    with open(run_id_file, 'r') as f:
-      run_id = f.read().strip()
-  else:
-    run_id = ''
-
-  # Build from sources new and base engines
-  if str(run['_id']) != run_id:
-    if os.path.exists(run_id_file): os.remove(run_id_file)
-    setup_engine(new_engine, worker_dir, run['args']['resolved_new'], repo_url, worker_info['concurrency'])
-    setup_engine(base_engine, worker_dir, run['args']['resolved_base'], repo_url, worker_info['concurrency'])
-    with open(run_id_file, 'w') as f:
-      f.write(str(run['_id']))
+  # Build from sources new and base engines as needed
+  if not os.path.exists(new_engine):
+    setup_engine(new_engine, worker_dir, sha_new, repo_url, worker_info['concurrency'])
+  if not os.path.exists(base_engine):
+    setup_engine(base_engine, worker_dir, sha_base, repo_url, worker_info['concurrency'])
 
   os.chdir(testing_dir)
 
@@ -431,8 +434,8 @@ def run_games(worker_info, password, remote, run, task_id):
           ['-resign', 'movecount=8', 'score=800', '-draw', 'movenumber=34',
            'movecount=8', 'score=20', '-concurrency', str(games_concurrency)] + pgn_cmd + \
           ['-variant', run['args']['variant']] + \
-          ['-engine', 'name=stockfish', 'cmd=stockfish'] + new_options + ['_spsa_'] + \
-          ['-engine', 'name=base', 'cmd=base'] + base_options + ['_spsa_'] + \
+          ['-engine', 'name=stockfish', 'cmd=%s' % (new_engine_name)] + new_options + ['_spsa_'] + \
+          ['-engine', 'name=base', 'cmd=%s' % (base_engine_name)'] + base_options + ['_spsa_'] + \
           ['-each', 'proto=uci', 'tc=%s' % (scaled_tc)] + nodestime_cmd + threads_cmd + book_cmd
 
     task_status = launch_cutechess(cmd, remote, result, spsa_tuning, games_to_play, tc_limit * games_to_play / min(games_to_play, games_concurrency))


### PR DESCRIPTION
As discussed in https://github.com/glinscott/fishtest/pull/258 and requested by @ppigazzini

keep the 25 most recent binaries on the worker, and reuse instead of recompile.

This should allow to further reduce the batch size without having the compile overhead.

