### PR TITLE
Reduce default SPSA A to be 10% of total iterations

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -120,7 +120,7 @@
   <div class="control-group stop_rule spsa">
     <label class="control-label">SPSA A:</label>
     <div class="controls">
-			<input name="spsa_A" value="${args.get('spsa', {'A': 5000})['A']}">
+      <input name="spsa_A" value="${args.get('spsa', {'A': 1000})['A']}">
     </div>
   </div>
   <div class="control-group stop_rule spsa">


### PR DESCRIPTION
In 2016 I updated the SPSA readme based upon Spall's 1998 paper but didn't think to update this default value