### PR TITLE
Use the string literal '' as iter() sentinel

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -161,6 +161,8 @@ def kill_process(p):
     subprocess.call(['taskkill', '/F', '/T', '/PID', str(p.pid)])
   else:
     p.kill()
+  p.wait()
+  p.stdout.close()
 
 def adjust_tc(tc, base_nps, concurrency):
   factor = 1000000.0 / base_nps
@@ -200,9 +202,8 @@ def adjust_tc(tc, base_nps, concurrency):
   return scaled_tc, tc_limit
 
 def enqueue_output(out, queue):
-  for line in iter(out.readline, b''):
+  for line in iter(out.readline, ''):
     queue.put(line)
-  out.close()
 
 def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
   global old_stats


### PR DESCRIPTION
File objects for stdin, stdout and stderr by default are opened in bynary mode
and require a byte string literal b'' as iter() sentinel.

We have opened the file objects for stdout and stderr in text mode using the
"universal_newlines=True" argument in subprocess.Popen() so the correct iter()
sentinel is the string literal ''.
Using b'' as sentinel is wrong and floods the queue with void lines.

Also move in kill_process() the closing of the stdout pipe.

Porting of a couple of my commits from official fishtest.