### PR TITLE
Fix update process

### DIFF
--- a/worker/updater.py
+++ b/worker/updater.py
@@ -33,9 +33,10 @@ def update():
   zip_file.extractall(update_dir)
   zip_file.close()
   prefix = os.path.commonprefix([n.filename for n in zip_file.infolist()])
-  fishtest_src = os.path.join(update_dir, prefix)
-  fishtest_dir = os.path.dirname(worker_dir) # fishtest_dir is assumed to be parent of worker_dir
-  copy_tree(fishtest_src, fishtest_dir)
+  worker_src = os.path.join(update_dir, os.path.join(prefix, 'worker'))
+  copy_tree(worker_src, worker_dir)
+  # the worker runs games from the "testing" folder so change the folder
+  os.chdir(worker_dir) 
   shutil.rmtree(update_dir)
   testing_dir = os.path.join(worker_dir, 'testing')
   if os.path.exists(testing_dir):

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -32,7 +32,7 @@ def setup_config_file(config_file):
   config.read(config_file)
 
   defaults = [('login', 'username', ''), ('login', 'password', ''),
-              ('parameters', 'host', '35.161.250.236'),
+              ('parameters', 'host', 'www.variantfishtest.org'),
               ('parameters', 'port', '6543'),
               ('parameters', 'concurrency', '3')]
 
@@ -116,7 +116,8 @@ def main():
   signal.signal(signal.SIGINT, on_sigint)
   signal.signal(signal.SIGTERM, on_sigint)
 
-  config_file = 'fishtest.cfg'
+  worker_dir = os.path.dirname(os.path.realpath(__file__))
+  config_file = os.path.join(worker_dir, "fishtest.cfg")
   config = setup_config_file(config_file)
   parser = OptionParser()
   parser.add_option('-n', '--host', dest='host', default=config.get('parameters', 'host'))


### PR DESCRIPTION
Update only the worker files so that the update process will work
also with a custom worker folder name.

Also:
 - the worker runs games from the "testing" folder, so change to the "worker"
folder before deleting the "testing" folder
 - write the configuration file in the "worker" folder instead that
in the executing folder
 - use the server fully qualified domain name