### PR TITLE
Catch the kill process error

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -233,13 +233,23 @@ def setup_engine(destination, worker_dir, sha, repo_url, concurrency):
   shutil.rmtree(tmp_dir)
 
 def kill_process(p):
-  if IS_WINDOWS:
-    # Kill doesn't kill subprocesses on Windows
-    subprocess.call(['taskkill', '/F', '/T', '/PID', str(p.pid)])
-  else:
-    p.kill()
-  p.wait()
-  p.stdout.close()
+  try:	
+    if IS_WINDOWS:
+      # Kill doesn't kill subprocesses on Windows
+      subprocess.call(['taskkill', '/F', '/T', '/PID', str(p.pid)])
+    else:
+      p.kill()
+  except:
+    print(
+      "Note: "
+      + str(sys.exc_info()[0])
+      + " killing the process pid: "
+      + str(p.pid)
+      + ", possibly already terminated"
+    )
+  finally:
+    p.wait()
+    p.stdout.close()
 
 def adjust_tc(tc, base_nps, concurrency):
   factor = 1000000.0 / base_nps

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -22,7 +22,7 @@ except ImportError:
   from configparser import ConfigParser  # Python3
   config = ConfigParser()
 
-WORKER_VERSION = 71
+WORKER_VERSION = 72
 ALIVE = True
 
 HTTP_TIMEOUT = 5.0


### PR DESCRIPTION
Print a warning message if a process kill fails.
The process kill is a safety measure against a hanging process.
At the moment all the running processes seems to run and close fine,
so we are always trying to kill an already closed process.
Some workers (WSL, msys2) running a SPSA test raise an exception that stops
the execution for some seconds slowing down the test.

Also raise version to 72.