### PR TITLE
Round to nearest integer

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -383,9 +383,9 @@ def launch_cutechess(cmd, remote, result, spsa_tuning, games_to_play, tc_limit):
 
   # Run cutechess-cli binary
   idx = cmd.index('_spsa_')
-  cmd = cmd[:idx] + ['option.{}={}'.format(x['name'], round(x['value'])) for x in spsa['w_params']] + cmd[idx+1:]
+  cmd = cmd[:idx] + ['option.{}={}'.format(x['name'], int(round(x['value']))) for x in spsa['w_params']] + cmd[idx+1:]
   idx = cmd.index('_spsa_')
-  cmd = cmd[:idx] + ['option.{}={}'.format(x['name'], round(x['value'])) for x in spsa['b_params']] + cmd[idx+1:]
+  cmd = cmd[:idx] + ['option.{}={}'.format(x['name'], int(round(x['value']))) for x in spsa['b_params']] + cmd[idx+1:]
 
   print(cmd)
   p = subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, bufsize=1, close_fds=not IS_WINDOWS)


### PR DESCRIPTION
`round()` returns:
 - `int` for python3
    https://docs.python.org/3/library/functions.html#round
 - `float` for python2
    https://docs.python.org/2.7/library/functions.html#round

Fix #30